### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,17 +7,20 @@ on:
     branches: [ main ]
 
 jobs:
-
   build_test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: 1.16
 
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Build
         run: |
@@ -25,10 +28,39 @@ jobs:
           go build -v ./...
 
       - name: Run Unit tests.
-        run: go test -v ./... -coverprofile=coverage.txt -covermode=atomic
+        run: |
+          mkdir -p ./coverage
+          go test -v ./... -coverprofile=./coverage/coverage-${{ matrix.os }}.txt -covermode=atomic
 
-      - name: Upload Coverage report to CodeCov
-        uses: codecov/codecov-action@v1.0.0
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v3
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
-          file: ./coverage.txt
+          name: coverage
+          path: ./coverage
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: build_test
+    if: ${{ always() }}
+    steps:
+      - name: Download coverage files
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage
+          path: ./coverage
+
+      - name: List coverage files
+        uses: actions/github-script@v3
+        id: files
+        with:
+          result-encoding: string
+          script: |
+            return require('fs').readdirSync('./coverage', {withFileTypes: true})
+              .filter(item => !item.isDirectory())
+              .map(item => `./coverage/${item.name}`)
+              .join(',');
+
+      - name: Send to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ${{ steps.files.outputs.result }}

--- a/arenaskl/arena_test.go
+++ b/arenaskl/arena_test.go
@@ -19,6 +19,7 @@ package arenaskl
 
 import (
 	"math"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,6 +28,10 @@ import (
 // TestArenaSizeOverflow tests that large allocations do not cause Arena's
 // internal size accounting to overflow and produce incorrect results.
 func TestArenaSizeOverflow(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("CI runners may run out of memory")
+	}
+
 	a := NewArena(math.MaxUint32)
 
 	// Allocating under the limit throws no error.

--- a/cf_test.go
+++ b/cf_test.go
@@ -1,7 +1,6 @@
 package lotusdb
 
 import (
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -23,10 +22,8 @@ func openTestColumnFamily(t *testing.T, db *LotusDB) *ColumnFamily {
 }
 
 func TestLotusDB_OpenColumnFamily(t *testing.T) {
-	opts := DefaultOptions(t.TempDir())
-	db := newTestDB(t, opts)
-
-	opencf := func(opts ColumnFamilyOptions) {
+	opencf := func(t *testing.T, opts ColumnFamilyOptions) {
+		db := newTestDB(t, DefaultOptions(t.TempDir()))
 		cf, err := db.OpenColumnFamily(opts)
 		assert.Nil(t, err)
 		assert.NotNil(t, cf)
@@ -34,31 +31,20 @@ func TestLotusDB_OpenColumnFamily(t *testing.T) {
 
 	t.Run("default", func(t *testing.T) {
 		cfopt := DefaultColumnFamilyOptions("cf-1")
-		opencf(cfopt)
+		opencf(t, cfopt)
 	})
 
 	t.Run("spec-dir", func(t *testing.T) {
 		cfopt := DefaultColumnFamilyOptions("cf-2")
-		dir, _ := os.MkdirTemp("", "lotusdb-opencf2")
-		defer func() {
-			_ = os.RemoveAll(dir)
-		}()
-		cfopt.DirPath = dir
-		opencf(cfopt)
+		cfopt.DirPath = t.TempDir()
+		opencf(t, cfopt)
 	})
 
 	t.Run("spec-val-dir", func(t *testing.T) {
 		cfopt := DefaultColumnFamilyOptions("cf-1")
-		dir, _ := os.MkdirTemp("", "lotusdb")
-		valDir, _ := os.MkdirTemp("", "lotus-val")
-		defer func() {
-			_ = os.RemoveAll(dir)
-			_ = os.RemoveAll(valDir)
-		}()
-
-		cfopt.DirPath = dir
-		cfopt.ValueLogDir = valDir
-		opencf(cfopt)
+		cfopt.DirPath = t.TempDir()
+		cfopt.ValueLogDir = t.TempDir()
+		opencf(t, cfopt)
 	})
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -413,21 +413,6 @@ func newTestDB(t *testing.T, opts Options) *LotusDB {
 	return db
 }
 
-func destroyDB(db *LotusDB) {
-	if db != nil {
-		_ = db.Close()
-		if err := os.RemoveAll(db.opts.DBPath); err != nil {
-			logger.Errorf("remove db path err.%v", err)
-		}
-		if err := os.RemoveAll(db.opts.CfOpts.IndexerDir); err != nil {
-			logger.Errorf("remove indexer path err.%v", err)
-		}
-		if err := os.RemoveAll(db.opts.CfOpts.ValueLogDir); err != nil {
-			logger.Errorf("remove vlog path err.%v", err)
-		}
-	}
-}
-
 const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
 
 func init() {

--- a/index/bptree.go
+++ b/index/bptree.go
@@ -1,9 +1,10 @@
 package index
 
 import (
-	"github.com/flower-corp/lotusdb/logger"
 	"strings"
 	"time"
+
+	"github.com/flower-corp/lotusdb/logger"
 
 	"go.etcd.io/bbolt"
 )
@@ -88,15 +89,18 @@ func NewBPTree(opt BPTreeOptions) (*BPTree, error) {
 
 	tx, err := db.Begin(true)
 	if err != nil {
+		_ = db.Close()
 		return nil, err
 	}
 
 	// cas create bucket
 	if _, err := tx.CreateBucketIfNotExists(opt.BucketName); err != nil {
+		_ = db.Close()
 		return nil, err
 	}
 	// commit operation
 	if err := tx.Commit(); err != nil {
+		_ = db.Close()
 		return nil, err
 	}
 

--- a/ioselector/fileio.go
+++ b/ioselector/fileio.go
@@ -1,6 +1,10 @@
 package ioselector
 
-import "os"
+import (
+	"errors"
+	"io/fs"
+	"os"
+)
 
 // FileIOSelector represents using standard file I/O.
 type FileIOSelector struct {
@@ -41,7 +45,7 @@ func (fio *FileIOSelector) Close() error {
 
 // Delete file descriptor if we don`t use it anymore.
 func (fio *FileIOSelector) Delete() error {
-	if err := fio.fd.Close(); err != nil {
+	if err := fio.fd.Close(); err != nil && !errors.Is(err, fs.ErrClosed) {
 		return err
 	}
 	return os.Remove(fio.fd.Name())

--- a/ioselector/mmap.go
+++ b/ioselector/mmap.go
@@ -1,7 +1,9 @@
 package ioselector
 
 import (
+	"errors"
 	"io"
+	"io/fs"
 	"os"
 
 	"github.com/flower-corp/lotusdb/mmap"
@@ -80,7 +82,7 @@ func (lm *MMapSelector) Delete() error {
 	if err := lm.fd.Truncate(0); err != nil {
 		return err
 	}
-	if err := lm.fd.Close(); err != nil {
+	if err := lm.fd.Close(); err != nil && !errors.Is(err, fs.ErrClosed) {
 		return err
 	}
 	return os.Remove(lm.fd.Name())

--- a/logfile/log_file.go
+++ b/logfile/log_file.go
@@ -176,6 +176,10 @@ func (lf *LogFile) Sync() error {
 
 // Close current log file.
 func (lf *LogFile) Close() error {
+	if lf.IoSelector == nil {
+		return nil
+	}
+
 	return lf.IoSelector.Close()
 }
 

--- a/mmap/mmap_test.go
+++ b/mmap/mmap_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/flower-corp/lotusdb/logger"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/vlog.go
+++ b/vlog.go
@@ -202,10 +202,11 @@ func (vlog *valueLog) Sync() error {
 
 // Close only for the active log file.
 func (vlog *valueLog) Close() error {
-	// close discard channel
-	vlog.discard.closeChan()
-
 	var vlogErr error
+
+	// close discard channel and file
+	vlogErr = vlog.discard.close()
+
 	// close archived log files.
 	for _, lf := range vlog.logFiles {
 		if err := lf.Close(); err != nil {

--- a/vlog.go
+++ b/vlog.go
@@ -103,6 +103,7 @@ func openValueLog(opt vlogOptions) (*valueLog, error) {
 	// set total size in discard file, skip it if exist.
 	discard.setTotal(fids[len(fids)-1], uint32(opt.blockSize))
 	if err != nil {
+		_ = discard.close()
 		return nil, err
 	}
 
@@ -119,6 +120,7 @@ func openValueLog(opt vlogOptions) (*valueLog, error) {
 	}
 
 	if err := vlog.setLogFileState(); err != nil {
+		_ = discard.close()
 		return nil, err
 	}
 	go vlog.handleCompaction()

--- a/vlog_test.go
+++ b/vlog_test.go
@@ -386,15 +386,7 @@ func TestValueLog_Sync(t *testing.T) {
 }
 
 func TestValueLog_Close(t *testing.T) {
-	path, err := filepath.Abs(filepath.Join("/tmp", "vlog-test"))
-	assert.Nil(t, err)
-	err = os.MkdirAll(path, os.ModePerm)
-	assert.Nil(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(path)
-	}()
-	vlog, err := openValueLogForTest(path, 10<<20, logfile.MMap, 0.5)
+	vlog, err := openValueLogForTest(t.TempDir(), 10<<20, logfile.MMap, 0.5)
 	assert.Nil(t, err)
 
 	err = vlog.Close()

--- a/vlog_test.go
+++ b/vlog_test.go
@@ -165,14 +165,8 @@ func testValueLogWrite(t *testing.T, ioType logfile.IOType) {
 }
 
 func TestValueLog_WriteAfterReopen(t *testing.T) {
-	path, err := filepath.Abs(filepath.Join("/tmp", "vlog-test"))
-	assert.Nil(t, err)
-	err = os.MkdirAll(path, os.ModePerm)
-	assert.Nil(t, err)
+	path := t.TempDir()
 
-	defer func() {
-		_ = os.RemoveAll(path)
-	}()
 	vlog, err := openValueLogForTest(path, 100, logfile.FileIO, 0.5)
 	assert.Nil(t, err)
 
@@ -195,6 +189,10 @@ func TestValueLog_WriteAfterReopen(t *testing.T) {
 	// reopen it.
 	vlog, err = openValueLogForTest(path, 100, logfile.MMap, 0.5)
 	assert.Nil(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, vlog.Close())
+	})
+
 	pos2, _, err := vlog.Write(tests[1])
 	assert.Nil(t, err)
 	pos = append(pos, pos2)

--- a/vlog_test.go
+++ b/vlog_test.go
@@ -343,14 +343,8 @@ func testValueLogRead(t *testing.T, ioType logfile.IOType) {
 }
 
 func TestValueLog_ReadFromArchivedFile(t *testing.T) {
-	path, err := filepath.Abs(filepath.Join("/tmp", "vlog-test"))
-	assert.Nil(t, err)
-	err = os.MkdirAll(path, os.ModePerm)
-	assert.Nil(t, err)
+	path := t.TempDir()
 
-	defer func() {
-		_ = os.RemoveAll(path)
-	}()
 	vlog, err := openValueLogForTest(path, 10<<20, logfile.FileIO, 0.5)
 	assert.Nil(t, err)
 
@@ -365,6 +359,10 @@ func TestValueLog_ReadFromArchivedFile(t *testing.T) {
 
 	vlog1, err := openValueLogForTest(path, 10<<20, logfile.FileIO, 0.5)
 	assert.Nil(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, vlog1.Close())
+	})
+
 	e, err := vlog1.Read(0, 0)
 	assert.Nil(t, err)
 	assert.True(t, len(e.Key) > 0)

--- a/vlog_test.go
+++ b/vlog_test.go
@@ -105,16 +105,11 @@ func TestValueLog_Write(t *testing.T) {
 }
 
 func testValueLogWrite(t *testing.T, ioType logfile.IOType) {
-	path, err := filepath.Abs(filepath.Join("/tmp", "vlog-test"))
+	vlog, err := openValueLogForTest(t.TempDir(), 1024<<20, ioType, 0.5)
 	assert.Nil(t, err)
-	err = os.MkdirAll(path, os.ModePerm)
-	assert.Nil(t, err)
-
-	defer func() {
-		_ = os.RemoveAll(path)
-	}()
-	vlog, err := openValueLogForTest(path, 1024<<20, ioType, 0.5)
-	assert.Nil(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, vlog.Close())
+	})
 
 	type fields struct {
 		vlog *valueLog


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	assert.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```