### PR TITLE
Fix #85

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -150,19 +150,9 @@ func (b *Batch) Delete(key []byte) error {
 	}
 
 	b.mu.Lock()
-	position, err := b.db.index.Get(key)
-	if err != nil {
-		b.mu.Unlock()
-		return err
-	}
-	if position != nil {
-		// write to pendingWrites if the key exists
-		b.pendingWrites[string(key)] = &LogRecord{
-			Key:  key,
-			Type: LogRecordDeleted,
-		}
-	} else {
-		delete(b.pendingWrites, string(key))
+	b.pendingWrites[string(key)] = &LogRecord{
+		Key:  key,
+		Type: LogRecordDeleted,
 	}
 	b.mu.Unlock()
 


### PR DESCRIPTION
The issues here are related to those discussed in the previous meeting. If deletion is triggered before synchronization with the index occurs, the deletion will be lost. Would it be better to directly add a deletion record without checking if the index exists in this case?