### PR TITLE
#133 Specify the key behavior

### DIFF
--- a/db.go
+++ b/db.go
@@ -2,7 +2,6 @@ package lotusdb
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -91,7 +90,7 @@ func Open(options Options) (*DB, error) {
 		indexType:       options.IndexType,
 		dirPath:         options.DirPath,
 		partitionNum:    options.PartitionNum,
-		hashKeyFunction: options.KeyHashFunction,
+		keyHashFunction: options.KeyHashFunction,
 	})
 	if err != nil {
 		return nil, err
@@ -265,7 +264,7 @@ func (db *DB) Exist(key []byte) (bool, error) {
 // validateOptions validates the given options.
 func validateOptions(options *Options) error {
 	if options.DirPath == "" {
-		return errors.New("the database directory path can not be empty")
+		return ErrDBDirectoryISEmpty
 	}
 	if options.MemtableSize <= 0 {
 		options.MemtableSize = 64 << 20 // 64MB
@@ -323,7 +322,7 @@ func (db *DB) waitMemtableSpace() error {
 		}
 		db.activeMem = table
 	case <-timer.C:
-		return errors.New("wait memtable space timeout, try again later")
+		return ErrWaitMemtableSpaceTimeOut
 	}
 
 	return nil

--- a/errors.go
+++ b/errors.go
@@ -9,4 +9,7 @@ var (
 	ErrReadOnlyBatch   = errors.New("the batch is read only")
 	ErrBatchCommitted  = errors.New("the batch is committed")
 	ErrDBClosed        = errors.New("the database is closed")
+
+	ErrDBDirectoryISEmpty       = errors.New("the database directory path can not be empty")
+	ErrWaitMemtableSpaceTimeOut = errors.New("wait memtable space timeout, try again later")
 )

--- a/index.go
+++ b/index.go
@@ -61,10 +61,10 @@ type indexOptions struct {
 
 	partitionNum int // index partition nums for sharding
 
-	hashKeyFunction func([]byte) uint64 // hash function for sharding
+	keyHashFunction func([]byte) uint64 // hash function for sharding
 }
 
 func (io *indexOptions) getKeyPartition(key []byte) int {
-	hashFn := io.hashKeyFunction
+	hashFn := io.keyHashFunction
 	return int(hashFn(key) % uint64(io.partitionNum))
 }


### PR DESCRIPTION
1. Specify that when the key is `nil` or `len(key) = 0`, the index will return an error `ErrKeyIsEmpty`. The behavior is consistent with `hash` and `BTree`.
2. add more test case 
3. rename `indexOptions.hashKeyFunction` to `indexOptions.keyHashFunction` match `Options.KeyHashFunction`