### PR TITLE
fix the deadlock when closing db

### DIFF
--- a/db.go
+++ b/db.go
@@ -141,10 +141,10 @@ func Open(options Options) (*DB, error) {
 // Set the closed flag to true.
 // The DB instance cannot be used after closing.
 func (db *DB) Close() error {
-	db.mu.Lock()
-	defer db.mu.Unlock()
 	close(db.flushChan)
 	<-db.closeChan
+	db.mu.Lock()
+	defer db.mu.Unlock()
 	// close all memtables
 	for _, table := range db.immuMems {
 		if err := table.close(); err != nil {


### PR DESCRIPTION
## Problem
find in `bench_test.go: BenchmarkGet`
`db.Close()` hold `db.mu` and close  `flushChan`.
```go
db.mu.Lock()
defer db.mu.Unlock()
close(db.flushChan)
<-db.closeChan
```
At the same time, the `listenMemtableFlush -> db.flushMemtable` may trying hold `db.mu` to flush memtable.
```go
...
// delete old memtable kept in memory
db.mu.Lock()
if table == db.activeMem {
...
```
`listenMemtableFlush` blocked, it cannot send msg to `closeChan`, and `db.Close()` blocked in `<-db.closeChan`.
## Solve
close `flushChan` without `db.mu`.
```go
close(db.flushChan)
<-db.closeChan
db.mu.Lock()
defer db.mu.Unlock()
```