### PR TITLE
diskio add support trigger, close default.

### DIFF
--- a/db.go
+++ b/db.go
@@ -128,6 +128,7 @@ func Open(options Options) (*DB, error) {
 
 	// init diskIO
 	diskIO := new(DiskIO)
+	diskIO.support = options.DiskIOSupport
 	diskIO.targetPath = options.DirPath
 	diskIO.samplingInterval = options.DiskIOSamplingInterval
 	diskIO.windowSize = options.DiskIOSamplingWindow

--- a/diskio.go
+++ b/diskio.go
@@ -12,6 +12,7 @@ import (
 )
 
 type DiskIO struct {
+	support          bool     // switch diskio
 	targetPath       string   // db path, we use it to find disk device
 	samplingInterval int      // sampling time, millisecond
 	samplingWindow   []uint64 // sampling window is used to sample the average IoTime over a period of time
@@ -76,7 +77,7 @@ func (io *DiskIO) IsFree() (bool, error) {
 	// if runtime.GOOS != "linux" {
 	// 	return true, nil
 	// }
-	if io.busyRate < 0 {
+	if io.busyRate < 0 || !io.support {
 		return true, nil
 	}
 	io.mu.Lock()

--- a/options.go
+++ b/options.go
@@ -67,6 +67,9 @@ type Options struct {
 	// rate of io time in the sampling time is used to represent the busy state of io
 	DiskIOBusyRate float32
 
+	// DiskIOSupport
+	DiskIOSupport bool
+
 	// AutoCompactSupport support
 	AutoCompactSupport bool
 
@@ -151,6 +154,7 @@ var DefaultOptions = Options{
 	DiskIOSamplingWindow: 10,
 	//nolint:gomnd // default
 	DiskIOBusyRate:     0.5,
+	DiskIOSupport:      false,
 	AutoCompactSupport: true,
 	//nolint:gomnd // default
 	WaitMemSpaceTimeout: 100 * time.Millisecond,


### PR DESCRIPTION
When trigger autocompaction, we always return `free`state when diskio support is `false`.